### PR TITLE
added dark mode default to .toml config file

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -10,4 +10,6 @@ echo "\
 headless = true\n\
 enableCORS=false\n\
 port = $PORT\n\
-" > ~/.streamlit/config.toml
+
+[theme]
+base=\"dark"\n\" > ~/.streamlit/config.toml


### PR DESCRIPTION
Added dark mode to streamlit app by default to our .toml config file. 
Set [theme]='dark'